### PR TITLE
Added notification_count_increments option

### DIFF
--- a/config/push.php
+++ b/config/push.php
@@ -19,6 +19,16 @@ return [
         'project_id' => env('PUSH_FCM_PROJECT'),
         /** Options: android, apns, webpush */
         'platforms' => ['android', 'apns'],
+        'options' => [
+            'android' => [
+                /**
+                 * If enabled, setBadge will set the payload's android.notification.notification_count to 1.
+                 * This is because the Android notification dot auto-increments the badge by the given number.
+                 * See: https://developer.android.com/develop/ui/views/notifications/badges
+                 */
+                'notification_count_increments' => true,
+            ],
+        ],
     ],
 
 ];

--- a/src/Drivers/Fcm.php
+++ b/src/Drivers/Fcm.php
@@ -107,11 +107,12 @@ class Fcm extends Driver
 
     protected function setPayloadAndroid(PushNotification $notification, array $payload)
     {
-        if ( $clickAction = $notification->getExtraValue('action') ) {
+        if ($clickAction = $notification->getExtraValue('action')) {
             Arr::set($payload, 'android.notification.click_action', $clickAction);
         }
         if ($notification->getBadge() !== null) {
-            Arr::set($payload, 'android.notification.notification_count', (int) $notification->getBadge());
+            $increments = Arr::get($this->config, 'options.android.notification_count_increments');
+            Arr::set($payload, 'android.notification.notification_count', $increments ? 1 : (int) $notification->getBadge());
         }
         if ($sound = $notification->getSound()) {
             Arr::set($payload, 'android.notification.sound', $sound);

--- a/src/PushChannel.php
+++ b/src/PushChannel.php
@@ -2,16 +2,14 @@
 
 namespace Origami\Push;
 
-use Illuminate\Support\Arr;
-use Origami\Push\Contracts\Device;
-use Origami\Push\PushNotification;
-use Illuminate\Support\Collection;
-use Origami\Push\Contracts\Driver;
-use Illuminate\Support\Facades\Log;
-use Illuminate\Notifications\Notification;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Contracts\Config\Repository;
 use Illuminate\Notifications\Events\NotificationFailed;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use Origami\Push\Contracts\Device;
+use Origami\Push\Contracts\Driver;
 
 class PushChannel
 {
@@ -41,7 +39,6 @@ class PushChannel
      * Send the given notification.
      *
      * @param  mixed  $notifiable
-     * @param  \Illuminate\Notifications\Notification  $notification
      * @return void
      */
     public function send($notifiable, Notification $notification)
@@ -105,7 +102,7 @@ class PushChannel
         foreach ($responses as $response) {
             if ($response->isError()) {
                 $this->events->dispatch(new NotificationFailed($notifiable, $notification, static::class, array_merge($response->getData(), [
-                    'error' => $response->getError()
+                    'error' => $response->getError(),
                 ])));
             }
         }
@@ -127,8 +124,6 @@ class PushChannel
     }
 
     /**
-     * @param $notifiable
-     *
      * @return \Illuminate\Support\Collection
      */
     protected function getDevices($notifiable)
@@ -144,7 +139,7 @@ class PushChannel
         }
 
         return $devices->filter(function ($device) {
-            return ($device instanceof \Origami\Push\Contracts\Device);
+            return $device instanceof \Origami\Push\Contracts\Device;
         });
     }
 }


### PR DESCRIPTION
Fixes #1

The `setBadge` works differently on FCM depending on iOS and Android. iOS uses the number as the badge value but Android increments by this value, meaning sending two notifications with `setBadge(2)` will show 4.

This PR adds a new options array to the fcm config:

```
'fcm' => [
        'project_id' => env('PUSH_FCM_PROJECT'),
        /** Options: android, apns, webpush */
        'platforms' => ['android', 'apns'],
        'options' => [
            'android' => [
                /**
                 * If enabled, setBadge will set the payload's android.notification.notification_count to 1.
                 * This is because the Android notification dot auto-increments the badge by the given number.
                 * See: https://developer.android.com/develop/ui/views/notifications/badges
                 */
                'notification_count_increments' => true,
            ],
        ],
    ],
```

You should add this if upgrading.